### PR TITLE
refactor(node): update directory getter

### DIFF
--- a/src/.config/lint.js
+++ b/src/.config/lint.js
@@ -9,7 +9,7 @@ import { createJiti } from 'jiti'
 
 const jiti = createJiti(import.meta.url)
 const constants = await jiti.import('../shared/utils/constants.ts')
-// @ts-ignore
+// @ts-expect-error jiti import is untyped
 const POLYFILLS = constants.POLYFILLS
 
 const vueI18nConfiguration = vueI18n.configs.recommended

--- a/src/node/server/node.mjs
+++ b/src/node/server/node.mjs
@@ -1,7 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const root = process.argv[2] || process.cwd()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const root = path.resolve(__dirname, '../..')
 
 const certSuffix = process.env.CI ? '-ci' : '-dev'
 const certPath = path.join(root, `.config/certificates/ssl${certSuffix}.crt`)

--- a/src/node/server/static.mjs
+++ b/src/node/server/static.mjs
@@ -1,8 +1,11 @@
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const root = process.argv[2] || process.cwd()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const root = path.resolve(__dirname, '../..')
 
 const certSuffix = process.env.CI ? '-ci' : '-dev'
 const certPath = path.join(root, `.config/certificates/ssl${certSuffix}.crt`)
@@ -11,7 +14,7 @@ const keyPath = path.join(root, `.config/certificates/ssl${certSuffix}.key`)
 const serveProcess = spawn(
   'serve',
   [
-    'playground/.output/public',
+    path.join(root, 'playground/.output/public'),
     ...(fs.existsSync(certPath) && fs.existsSync(keyPath)
       ? ['--ssl-cert', certPath, '--ssl-key', keyPath]
       : []),


### PR DESCRIPTION
This pull request updates how server scripts determine their root directory and reference SSL certificate and playground paths. The main goal is to make path resolution more robust and consistent by using the file's directory as the base, rather than relying on the current working directory or process arguments.