### PR TITLE
feat(utils): align with downstream

### DIFF
--- a/src/.config/lint.js
+++ b/src/.config/lint.js
@@ -24,7 +24,7 @@ export const VIO_ESLINT_CONFIG = [
   prettierConfiguration, // must be last
 
   {
-    files: ['.config/**/*', 'server/**/*'],
+    files: ['.config/**/*', 'node/**/*', 'server/**/*'],
     rules: {
       'compat/compat': 'off',
     },

--- a/src/app/composables/networking.ts
+++ b/src/app/composables/networking.ts
@@ -1,6 +1,7 @@
 export const useGetServiceHref = () => {
   const host = useHost()
   const runtimeConfig = useRuntimeConfig()
+  const isTesting = useIsTesting()
 
   return ({
     isSsr = true,
@@ -8,12 +9,13 @@ export const useGetServiceHref = () => {
     port,
   }: {
     isSsr?: boolean
-    name?: string
+    name: string
     port?: number
   }) =>
     getServiceHref({
       host,
       isSsr,
+      isTesting,
       name,
       port,
       stagingHost: runtimeConfig.public.vio.stagingHost,

--- a/src/app/composables/testing.ts
+++ b/src/app/composables/testing.ts
@@ -1,6 +1,13 @@
-export const useIsTesting = () => {
-  const cookie = useCookie(TESTING_COOKIE_NAME).value
+export const useIsTesting = ({
+  isCookieEnabled = true,
+}: { isCookieEnabled?: boolean } | undefined = {}) => {
   const runtimeConfig = useRuntimeConfig()
 
-  return runtimeConfig.public.vio.isTesting || !!cookie
+  const isTestingByRuntimeConfig = runtimeConfig.public.vio.isTesting
+  if (isTestingByRuntimeConfig) return true
+
+  if (isCookieEnabled) {
+    const isTestingByCookie = !!useCookie(TESTING_COOKIE_NAME).value
+    if (isTestingByCookie) return true
+  }
 }

--- a/src/app/utils/dateTime.ts
+++ b/src/app/utils/dateTime.ts
@@ -1,5 +1,5 @@
-export const getTimezone = () =>
-  useNuxtApp().ssrContext?.event.context.$timezone ||
+export const getTimeZone = () =>
+  useNuxtApp().ssrContext?.event.context.$timeZone ||
   useCookie(TIMEZONE_COOKIE_NAME, {
     httpOnly: false,
     sameSite: 'strict',

--- a/src/node/static/environment.ts
+++ b/src/node/static/environment.ts
@@ -5,3 +5,4 @@ export const IS_IN_FRONTEND_DEVELOPMENT = !IS_IN_PRODUCTION && !IS_IN_STACK
 export const SITE_URL =
   process.env.NUXT_PUBLIC_I18N_BASE_URL ||
   `https://${process.env.HOST || 'app.localhost'}:${process.env.PORT || '3000'}`
+export const SITE_URL_TYPED = new URL(SITE_URL)

--- a/src/server/middleware/dateTime.ts
+++ b/src/server/middleware/dateTime.ts
@@ -1,9 +1,10 @@
 export default defineEventHandler(async (event) => {
-  event.context.$timezone = await getTimezone(event)
+  const isTesting = useIsTesting()
+  event.context.$timeZone = await getTimeZone({ event, isTesting })
 })
 
 declare module 'h3' {
   interface H3EventContext {
-    $timezone?: string
+    $timeZone?: string
   }
 }

--- a/src/server/utils/dateTime.ts
+++ b/src/server/utils/dateTime.ts
@@ -1,28 +1,41 @@
 import type { H3Event } from 'h3'
 
-export const getTimezone = async (event: H3Event) => {
-  const timezoneBySsr = event.context.$timezone
+export const getTimeZone = async ({
+  event,
+  isTesting,
+}: {
+  event: H3Event
+  isTesting?: boolean
+}) => {
+  const timeZoneBySsr = event.context.$timeZone
 
-  if (timezoneBySsr) return timezoneBySsr
+  if (timeZoneBySsr) return timeZoneBySsr
 
-  const timezoneByCookie = getCookie(event, TIMEZONE_COOKIE_NAME)
+  const timeZoneByCookie = getCookie(event, TIMEZONE_COOKIE_NAME)
 
-  if (timezoneByCookie) return timezoneByCookie
+  if (timeZoneByCookie) return timeZoneByCookie
 
-  const ip = getRequestIP(event, { xForwardedFor: true })
+  if (!isTesting) {
+    const ip = getRequestIP(event, { xForwardedFor: true })
 
-  if (ip) {
-    const timezoneByIpApi = await getTimezoneByIpApi(ip)
+    if (ip) {
+      const timeZoneByIpApi = await getTimeZoneByIpApi({ ip })
 
-    if (timezoneByIpApi) return timezoneByIpApi
+      if (timeZoneByIpApi) return timeZoneByIpApi
+    }
   }
 }
 
-export const getTimezoneByIpApi = async (ip: string) => {
-  if (isTestingServer()) return // TODO: mock
+export const useTimeZone = async () => {
+  const event = useEvent()
+  const isTesting = useIsTesting()
 
+  return await getTimeZone({ event, isTesting })
+}
+
+export const getTimeZoneByIpApi = async ({ ip }: { ip: string }) => {
   const ipApiResult = await $fetch<{ timezone: string }>(
-    `http://ip-api.com/json/${ip}`,
+    `http://geoip:8080/${ip}`,
   ).catch(() => {})
 
   if (ipApiResult) {

--- a/src/server/utils/networking.ts
+++ b/src/server/utils/networking.ts
@@ -1,6 +1,9 @@
-export const useGetServiceHref = () => {
-  const host = useHost()
+import type { H3Event } from 'h3'
+
+export const useGetServiceHref = ({ event }: { event?: H3Event } = {}) => {
+  const host = useHost({ event })
   const runtimeConfig = useRuntimeConfig()
+  const isTesting = useIsTesting()
 
   return ({
     isSsr = true,
@@ -8,21 +11,22 @@ export const useGetServiceHref = () => {
     port,
   }: {
     isSsr?: boolean
-    name?: string
+    name: string
     port?: number
   }) =>
     getServiceHref({
       host,
       isSsr,
+      isTesting,
       name,
       port,
       stagingHost: runtimeConfig.public.vio.stagingHost,
-    }).toString()
+    })
 }
 
-export const useHost = () => {
-  const event = useEvent()
-  const host = getHost(event)
+export const useHost = ({ event }: { event?: H3Event } = {}) => {
+  const { siteUrlTyped: siteUrl } = useSiteUrl()
+  const host = event ? getHost(event) : siteUrl.host
 
   if (!host) throw new Error('Host is not given!')
 

--- a/src/server/utils/testing.ts
+++ b/src/server/utils/testing.ts
@@ -1,13 +1,32 @@
 import type { H3Event } from 'h3'
 
-export const isTestingServer = (event?: H3Event) => {
-  const isTestingByRuntimeConfig = useRuntimeConfig().public.vio.isTesting
+export const useIsTesting = ({
+  isCookieEnabled = true,
+}:
+  | {
+      isCookieEnabled?: boolean
+    }
+  | undefined = {}) => {
+  const event = useEvent()
+  const runtimeConfig = useRuntimeConfig()
 
+  return getIsTesting({ event, isCookieEnabled, runtimeConfig })
+}
+
+export const getIsTesting = ({
+  event,
+  isCookieEnabled,
+  runtimeConfig,
+}: {
+  event?: H3Event
+  isCookieEnabled?: boolean
+  runtimeConfig: ReturnType<typeof useRuntimeConfig>
+}) => {
+  const isTestingByRuntimeConfig = runtimeConfig.public.vio.isTesting
   if (isTestingByRuntimeConfig) return true
 
-  if (event) {
+  if (isCookieEnabled && event) {
     const isTestingByCookie = !!getCookie(event, TESTING_COOKIE_NAME)
-
     if (isTestingByCookie) return true
   }
 }

--- a/src/shared/utils/networking.ts
+++ b/src/shared/utils/networking.ts
@@ -3,6 +3,7 @@ import type { H3Event } from 'h3'
 import { computed, reactive } from 'vue'
 import type { Ref } from 'vue'
 
+import { SITE_URL_TYPED } from '../../node/static'
 import type { ApiData, BackendError } from '../types/api'
 
 export const getApiDataDefault = (): ApiData =>
@@ -87,25 +88,38 @@ export const getHost = (event: H3Event) => {
 export const getServiceHref = ({
   host,
   isSsr = true,
+  isTesting,
   name,
   port,
   stagingHost,
 }: {
-  host: string
+  host?: string
   isSsr?: boolean
-  name?: string
+  isTesting?: boolean
+  name: string
   port?: number
   stagingHost?: string
 }) => {
-  const nameSubdomain = name?.replaceAll('_', '-')
+  const nameSubdomain =
+    name !== VIO_SITE_NAME ? name?.replaceAll('_', '-') : undefined
   const nameSubdomainString = nameSubdomain ? `${nameSubdomain}.` : ''
   const portString = port ? `:${port}` : ''
 
+  if (isTesting) {
+    return `${SITE_URL_TYPED.protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}`
+  }
+
   if (stagingHost) {
     return `https://${nameSubdomainString}${stagingHost}`
-  } else if (isSsr && import.meta.server) {
-    return `http://${name}${portString}`
-  } else {
-    return `https://${nameSubdomainString}${getRootHost(host)}`
   }
+
+  if (import.meta.server && isSsr) {
+    return `http://${name}${portString}`
+  }
+
+  if (host) {
+    return `https://${nameSubdomainString}${host}`
+  }
+
+  throw new Error('Could not get service href!')
 }


### PR DESCRIPTION
This pull request refactors and enhances the handling of service URLs, timezone detection, and testing environment checks across both client and server code.
**Timezone and Testing Detection Improvements:**

- Refactored timezone utilities by renaming `getTimezone` to `getTimeZone` and updating its interface to accept an object with `event` and `isTesting` parameters, improving clarity and testability. Added a new `useTimeZone` composable for unified timezone retrieval.
- Enhanced testing detection logic by refactoring `useIsTesting` to accept options such as `event` and `isCookieEnabled`, and by introducing a shared `getIsTesting` utility. This change ensures consistent testing checks across client and server.

**Service URL and Networking Refactor:**

- Refactored `useGetServiceHref` and `useHost` to accept explicit arguments (such as `event`) and rely on improved host and testing detection logic. This makes service URL generation more predictable and testable.
- Updated the `getServiceHref` utility to handle the new testing logic, use the new `SITE_URL_TYPED` constant, and throw explicit errors if host resolution fails.

**Configuration and Linting:**

- Updated the lint configuration to include the `node` directory, ensuring consistent linting across more of the codebase.