### PR TITLE
feat(strapi)!: use default name

### DIFF
--- a/src/app/composables/networking.ts
+++ b/src/app/composables/networking.ts
@@ -33,3 +33,13 @@ export const useHost = () => {
 
   return host
 }
+
+export const useServiceFetch = (
+  options: Parameters<ReturnType<typeof useGetServiceHref>>[0],
+) => {
+  const getServiceHref = useGetServiceHref()
+
+  return $fetch.create({
+    baseURL: getServiceHref(options),
+  })
+}

--- a/src/app/composables/networking.ts
+++ b/src/app/composables/networking.ts
@@ -6,10 +6,12 @@ export const useGetServiceHref = () => {
   return ({
     isSsr = true,
     name,
+    path,
     port,
   }: {
     isSsr?: boolean
     name: string
+    path?: string
     port?: number
   }) =>
     getServiceHref({
@@ -17,6 +19,7 @@ export const useGetServiceHref = () => {
       isSsr,
       isTesting,
       name,
+      path,
       port,
       stagingHost: runtimeConfig.public.vio.stagingHost,
     })

--- a/src/app/composables/strapi.ts
+++ b/src/app/composables/strapi.ts
@@ -1,7 +1,8 @@
-export const useStrapiFetch = () => {
-  const getServiceHref = useGetServiceHref()
-
-  return $fetch.create({
-    baseURL: getServiceHref({ name: 'creal_strapi', port: 1337 }) + '/api',
+export const useStrapiFetch = (
+  options?: Parameters<ReturnType<typeof useGetServiceHref>>[0],
+) =>
+  useServiceFetch({
+    ...(options ? options : {}),
+    name: options?.name || 'strapi',
+    path: options?.path || '/api',
   })
-}

--- a/src/server/utils/networking.ts
+++ b/src/server/utils/networking.ts
@@ -8,10 +8,12 @@ export const useGetServiceHref = ({ event }: { event?: H3Event } = {}) => {
   return ({
     isSsr = true,
     name,
+    path,
     port,
   }: {
     isSsr?: boolean
     name: string
+    path?: string
     port?: number
   }) =>
     getServiceHref({
@@ -19,6 +21,7 @@ export const useGetServiceHref = ({ event }: { event?: H3Event } = {}) => {
       isSsr,
       isTesting,
       name,
+      path,
       port,
       stagingHost: runtimeConfig.public.vio.stagingHost,
     })

--- a/src/shared/utils/networking.ts
+++ b/src/shared/utils/networking.ts
@@ -90,6 +90,7 @@ export const getServiceHref = ({
   isSsr = true,
   isTesting,
   name,
+  path,
   port,
   stagingHost,
 }: {
@@ -97,6 +98,7 @@ export const getServiceHref = ({
   isSsr?: boolean
   isTesting?: boolean
   name: string
+  path?: string
   port?: number
   stagingHost?: string
 }) => {
@@ -104,21 +106,22 @@ export const getServiceHref = ({
     name !== VIO_SITE_NAME ? name?.replaceAll('_', '-') : undefined
   const nameSubdomainString = nameSubdomain ? `${nameSubdomain}.` : ''
   const portString = port ? `:${port}` : ''
+  const pathString = path ? `/${path.replace(/^\/+/, '')}` : ''
 
   if (isTesting) {
-    return `${SITE_URL_TYPED.protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}`
+    return `${SITE_URL_TYPED.protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}${pathString}`
   }
 
   if (stagingHost) {
-    return `https://${nameSubdomainString}${stagingHost}`
+    return `https://${nameSubdomainString}${stagingHost}${pathString}`
   }
 
   if (import.meta.server && isSsr) {
-    return `http://${name}${portString}`
+    return `http://${name}${portString}${pathString}`
   }
 
   if (host) {
-    return `https://${nameSubdomainString}${host}`
+    return `https://${nameSubdomainString}${host}${pathString}`
   }
 
   throw new Error('Could not get service href!')


### PR DESCRIPTION
This pull request refactors and extends the networking utilities to support specifying a `path` when constructing service URLs and fetching from services. It also introduces a more generic `useServiceFetch` composable and updates the Strapi fetch utility to leverage this new flexibility.

**Networking utilities enhancements:**

* Added an optional `path` parameter to `getServiceHref` and related composables (`useGetServiceHref`) to allow building service URLs with custom paths.
* Updated the logic in `getServiceHref` to append the `path` to the generated URL in all relevant environments (testing, staging, SSR, and client).

**Composable and fetch utility improvements:**

* Introduced a new `useServiceFetch` composable that creates a `$fetch` instance with a base URL determined by `useGetServiceHref` and the provided options.
* Refactored `useStrapiFetch` to use `useServiceFetch`, making it more flexible by allowing override of `name` and `path` (defaulting to `'strapi'` and `'api'` respectively).