### PR TITLE
refactor(networking)!: extensible SERVICES map with fixed subdomain/staging-host handling

### DIFF
--- a/src/app/composables/networking.ts
+++ b/src/app/composables/networking.ts
@@ -16,6 +16,7 @@ export const useGetServiceHref = () => {
   }) =>
     getServiceHref({
       host,
+      isServer: import.meta.server,
       isSsr,
       isTesting,
       name,

--- a/src/app/composables/networking.ts
+++ b/src/app/composables/networking.ts
@@ -4,24 +4,21 @@ export const useGetServiceHref = () => {
   const isTesting = useIsTesting()
 
   return ({
-    isSsr = true,
+    allowInternal = true,
     name,
     path,
-    port,
   }: {
-    isSsr?: boolean
-    name: string
+    allowInternal?: boolean
+    name: ServiceName
     path?: string
-    port?: number
   }) =>
     getServiceHref({
+      allowInternal,
       host,
       isServer: import.meta.server,
-      isSsr,
       isTesting,
       name,
       path,
-      port,
       stagingHost: runtimeConfig.public.vio.stagingHost,
     })
 }

--- a/src/app/composables/networking.ts
+++ b/src/app/composables/networking.ts
@@ -19,6 +19,7 @@ export const useGetServiceHref = () => {
       isTesting,
       name,
       path,
+      services: runtimeConfig.public.vio.services,
       stagingHost: runtimeConfig.public.vio.stagingHost,
     })
 }

--- a/src/app/composables/strapi.ts
+++ b/src/app/composables/strapi.ts
@@ -5,5 +5,4 @@ export const useStrapiFetch = (
     ...(options ? options : {}),
     name: options?.name || 'strapi',
     path: options?.path || '/api',
-    port: options?.port || 1337,
   })

--- a/src/node/networking.ts
+++ b/src/node/networking.ts
@@ -31,6 +31,7 @@ export const getServiceHref = ({
   isTesting,
   name,
   path,
+  protocol = SITE_URL_TYPED.protocol,
   stagingHost,
 }: {
   allowInternal?: boolean
@@ -39,6 +40,7 @@ export const getServiceHref = ({
   isTesting?: boolean
   name: ServiceName
   path?: string
+  protocol?: string
   stagingHost?: string
 }) => {
   const { hasSubdomain, port } = SERVICES[name]
@@ -53,13 +55,13 @@ export const getServiceHref = ({
   if (isTesting) {
     assertHasSubdomain()
 
-    return `${SITE_URL_TYPED.protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}${pathString}`
+    return `${protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}${pathString}`
   }
 
   if (stagingHost) {
     assertHasSubdomain()
 
-    return `https://${nameSubdomainString}${stagingHost}${pathString}`
+    return `${protocol}//${nameSubdomainString}${stagingHost}${pathString}`
   }
 
   if (isServer && allowInternal) {
@@ -69,7 +71,7 @@ export const getServiceHref = ({
   if (host) {
     assertHasSubdomain()
 
-    return `https://${nameSubdomainString}${getRootHost(host)}${pathString}`
+    return `${protocol}//${nameSubdomainString}${getRootHost(host)}${pathString}`
   }
 
   throw new Error('Could not get service href!')

--- a/src/node/networking.ts
+++ b/src/node/networking.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from 'h3'
 
-import { VIO_SITE_NAME } from '../shared/utils/constants'
+import { SERVICES } from './services'
+import type { ServiceName } from './services'
 import { SITE_URL_TYPED } from './static'
 
 export const getHost = (event: H3Event) => {
@@ -24,43 +25,50 @@ export const getRootHost = (host: string) => {
 }
 
 export const getServiceHref = ({
+  allowInternal = true,
   host,
   isServer,
-  isSsr = true,
   isTesting,
   name,
   path,
-  port,
   stagingHost,
 }: {
+  allowInternal?: boolean
   host?: string
   isServer: boolean
-  isSsr?: boolean
   isTesting?: boolean
-  name: string
+  name: ServiceName
   path?: string
-  port?: number
   stagingHost?: string
 }) => {
-  const nameSubdomain =
-    name !== VIO_SITE_NAME ? name?.replaceAll('_', '-') : undefined
-  const nameSubdomainString = nameSubdomain ? `${nameSubdomain}.` : ''
-  const portString = port ? `:${port}` : ''
+  const { hasSubdomain, port } = SERVICES[name]
+  const nameSubdomainString = `${name.replaceAll('_', '-')}.`
   const pathString = path ? `/${path.replace(/^\/+/, '')}` : ''
 
+  const assertHasSubdomain = () => {
+    if (!hasSubdomain)
+      throw new Error(`Service "${name}" has no public subdomain!`)
+  }
+
   if (isTesting) {
+    assertHasSubdomain()
+
     return `${SITE_URL_TYPED.protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}${pathString}`
   }
 
   if (stagingHost) {
+    assertHasSubdomain()
+
     return `https://${nameSubdomainString}${stagingHost}${pathString}`
   }
 
-  if (isServer && isSsr) {
-    return `http://${name}${portString}${pathString}`
+  if (isServer && allowInternal) {
+    return `http://${name}:${port}${pathString}`
   }
 
   if (host) {
+    assertHasSubdomain()
+
     return `https://${nameSubdomainString}${getRootHost(host)}${pathString}`
   }
 

--- a/src/node/networking.ts
+++ b/src/node/networking.ts
@@ -1,0 +1,68 @@
+import type { H3Event } from 'h3'
+
+import { VIO_SITE_NAME } from '../shared/utils/constants'
+import { SITE_URL_TYPED } from './static'
+
+export const getHost = (event: H3Event) => {
+  const host = event.node.req.headers.host
+
+  if (!host) throw new Error('Host header is not given!')
+
+  return host
+}
+
+export const getRootHost = (host: string) => {
+  const hostParts = host.split('.')
+  const hostPartsLast = hostParts[hostParts.length - 1]
+
+  if (hostPartsLast && /^localhost(:[0-9]+)?$/.test(hostPartsLast))
+    return hostPartsLast
+
+  if (hostParts.length === 1) return hostParts[0]
+
+  return `${hostParts[hostParts.length - 2]}.${hostPartsLast}`
+}
+
+export const getServiceHref = ({
+  host,
+  isServer,
+  isSsr = true,
+  isTesting,
+  name,
+  path,
+  port,
+  stagingHost,
+}: {
+  host?: string
+  isServer: boolean
+  isSsr?: boolean
+  isTesting?: boolean
+  name: string
+  path?: string
+  port?: number
+  stagingHost?: string
+}) => {
+  const nameSubdomain =
+    name !== VIO_SITE_NAME ? name?.replaceAll('_', '-') : undefined
+  const nameSubdomainString = nameSubdomain ? `${nameSubdomain}.` : ''
+  const portString = port ? `:${port}` : ''
+  const pathString = path ? `/${path.replace(/^\/+/, '')}` : ''
+
+  if (isTesting) {
+    return `${SITE_URL_TYPED.protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}${pathString}`
+  }
+
+  if (stagingHost) {
+    return `https://${nameSubdomainString}${stagingHost}${pathString}`
+  }
+
+  if (isServer && isSsr) {
+    return `http://${name}${portString}${pathString}`
+  }
+
+  if (host) {
+    return `https://${nameSubdomainString}${getRootHost(host)}${pathString}`
+  }
+
+  throw new Error('Could not get service href!')
+}

--- a/src/node/networking.ts
+++ b/src/node/networking.ts
@@ -1,7 +1,7 @@
 import type { H3Event } from 'h3'
 
 import { SERVICES } from './services'
-import type { ServiceName } from './services'
+import type { Service, ServiceName } from './services'
 import { SITE_URL_TYPED } from './static'
 
 export const getHost = (event: H3Event) => {
@@ -32,6 +32,7 @@ export const getServiceHref = ({
   name,
   path,
   protocol = SITE_URL_TYPED.protocol,
+  services = SERVICES,
   stagingHost,
 }: {
   allowInternal?: boolean
@@ -41,9 +42,14 @@ export const getServiceHref = ({
   name: ServiceName
   path?: string
   protocol?: string
+  services?: Record<string, Service>
   stagingHost?: string
 }) => {
-  const { hasSubdomain, port } = SERVICES[name]
+  const service = services[name]
+
+  if (!service) throw new Error(`Service "${name}" is not registered!`)
+
+  const { hasSubdomain, port } = service
   const nameSubdomainString = `${name.replaceAll('_', '-')}.`
   const pathString = path ? `/${path.replace(/^\/+/, '')}` : ''
 

--- a/src/node/services.ts
+++ b/src/node/services.ts
@@ -1,5 +1,11 @@
+export type Service = {
+  hasSubdomain: boolean
+  port: number
+}
+
 export const SERVICES = {
   strapi: { hasSubdomain: true, port: 1337 },
-} as const satisfies Record<string, { hasSubdomain: boolean; port: number }>
+} as const satisfies Record<string, Service>
 
-export type ServiceName = keyof typeof SERVICES
+// The open string branch accepts services registered by extending projects through VIO_NUXT_BASE_CONFIG's `services` option, while still keeping autocomplete for the built-in names.
+export type ServiceName = keyof typeof SERVICES | (string & {})

--- a/src/node/services.ts
+++ b/src/node/services.ts
@@ -1,0 +1,5 @@
+export const SERVICES = {
+  strapi: { hasSubdomain: true, port: 1337 },
+} as const satisfies Record<string, { hasSubdomain: boolean; port: number }>
+
+export type ServiceName = keyof typeof SERVICES

--- a/src/node/static/nuxt.ts
+++ b/src/node/static/nuxt.ts
@@ -1,11 +1,15 @@
 import type { defineNuxtConfig } from 'nuxt/config'
 
+import type { Service } from '../services'
+import { SERVICES } from '../services'
 import { IS_IN_FRONTEND_DEVELOPMENT } from './'
 
 export const VIO_NUXT_BASE_CONFIG = ({
+  services,
   siteName,
   stagingHost,
 }: {
+  services?: Record<string, Service>
   siteName: string
   stagingHost?: string
 }) =>
@@ -18,6 +22,7 @@ export const VIO_NUXT_BASE_CONFIG = ({
     runtimeConfig: {
       public: {
         vio: {
+          services: { ...SERVICES, ...services },
           stagingHost: IS_IN_FRONTEND_DEVELOPMENT ? stagingHost : undefined,
         },
       },

--- a/src/server/utils/networking.ts
+++ b/src/server/utils/networking.ts
@@ -18,6 +18,7 @@ export const useGetServiceHref = ({ event }: { event?: H3Event } = {}) => {
   }) =>
     getServiceHref({
       host,
+      isServer: import.meta.server,
       isSsr,
       isTesting,
       name,

--- a/src/server/utils/networking.ts
+++ b/src/server/utils/networking.ts
@@ -21,6 +21,7 @@ export const useGetServiceHref = ({ event }: { event?: H3Event } = {}) => {
       isTesting,
       name,
       path,
+      services: runtimeConfig.public.vio.services,
       stagingHost: runtimeConfig.public.vio.stagingHost,
     })
 }

--- a/src/server/utils/networking.ts
+++ b/src/server/utils/networking.ts
@@ -6,24 +6,21 @@ export const useGetServiceHref = ({ event }: { event?: H3Event } = {}) => {
   const isTesting = useIsTesting()
 
   return ({
-    isSsr = true,
+    allowInternal = true,
     name,
     path,
-    port,
   }: {
-    isSsr?: boolean
-    name: string
+    allowInternal?: boolean
+    name: ServiceName
     path?: string
-    port?: number
   }) =>
     getServiceHref({
+      allowInternal,
       host,
       isServer: import.meta.server,
-      isSsr,
       isTesting,
       name,
       path,
-      port,
       stagingHost: runtimeConfig.public.vio.stagingHost,
     })
 }

--- a/src/shared/utils/networking.ts
+++ b/src/shared/utils/networking.ts
@@ -87,6 +87,7 @@ export const getHost = (event: H3Event) => {
 
 export const getServiceHref = ({
   host,
+  isServer,
   isSsr = true,
   isTesting,
   name,
@@ -95,6 +96,7 @@ export const getServiceHref = ({
   stagingHost,
 }: {
   host?: string
+  isServer: boolean
   isSsr?: boolean
   isTesting?: boolean
   name: string
@@ -116,7 +118,7 @@ export const getServiceHref = ({
     return `https://${nameSubdomainString}${stagingHost}${pathString}`
   }
 
-  if (import.meta.server && isSsr) {
+  if (isServer && isSsr) {
     return `http://${name}${portString}${pathString}`
   }
 

--- a/src/shared/utils/networking.ts
+++ b/src/shared/utils/networking.ts
@@ -1,10 +1,10 @@
 import type { CombinedError } from '@urql/core'
-import type { H3Event } from 'h3'
 import { computed, reactive } from 'vue'
 import type { Ref } from 'vue'
 
-import { SITE_URL_TYPED } from '../../node/static'
 import type { ApiData, BackendError } from '../types/api'
+
+export { getHost, getRootHost, getServiceHref } from '../../node/networking'
 
 export const getApiDataDefault = (): ApiData =>
   computed(() =>
@@ -63,68 +63,4 @@ export const getCombinedErrorMessages = (
   }
 
   return errorMessages
-}
-
-export const getRootHost = (host: string) => {
-  const hostParts = host.split('.')
-  const hostPartsLast = hostParts[hostParts.length - 1]
-
-  if (hostPartsLast && /^localhost(:[0-9]+)?$/.test(hostPartsLast))
-    return hostPartsLast
-
-  if (hostParts.length === 1) return hostParts[0]
-
-  return `${hostParts[hostParts.length - 2]}.${hostPartsLast}`
-}
-
-export const getHost = (event: H3Event) => {
-  const host = event.node.req.headers.host
-
-  if (!host) throw new Error('Host header is not given!')
-
-  return host
-}
-
-export const getServiceHref = ({
-  host,
-  isServer,
-  isSsr = true,
-  isTesting,
-  name,
-  path,
-  port,
-  stagingHost,
-}: {
-  host?: string
-  isServer: boolean
-  isSsr?: boolean
-  isTesting?: boolean
-  name: string
-  path?: string
-  port?: number
-  stagingHost?: string
-}) => {
-  const nameSubdomain =
-    name !== VIO_SITE_NAME ? name?.replaceAll('_', '-') : undefined
-  const nameSubdomainString = nameSubdomain ? `${nameSubdomain}.` : ''
-  const portString = port ? `:${port}` : ''
-  const pathString = path ? `/${path.replace(/^\/+/, '')}` : ''
-
-  if (isTesting) {
-    return `${SITE_URL_TYPED.protocol}//${nameSubdomainString}${SITE_URL_TYPED.host}${pathString}`
-  }
-
-  if (stagingHost) {
-    return `https://${nameSubdomainString}${stagingHost}${pathString}`
-  }
-
-  if (isServer && isSsr) {
-    return `http://${name}${portString}${pathString}`
-  }
-
-  if (host) {
-    return `https://${nameSubdomainString}${getRootHost(host)}${pathString}`
-  }
-
-  throw new Error('Could not get service href!')
 }

--- a/src/shared/utils/services.ts
+++ b/src/shared/utils/services.ts
@@ -1,0 +1,2 @@
+export { SERVICES } from '../../node/services'
+export type { ServiceName } from '../../node/services'

--- a/src/shared/utils/services.ts
+++ b/src/shared/utils/services.ts
@@ -1,2 +1,2 @@
 export { SERVICES } from '../../node/services'
-export type { ServiceName } from '../../node/services'
+export type { Service, ServiceName } from '../../node/services'


### PR DESCRIPTION
Replaces the freeform `name`/`port` pair on `getServiceHref` with a typed `SERVICES` map, and lets extending projects register their own services through `VIO_NUXT_BASE_CONFIG`'s new `services` option.

Also fixes two bugs found in review: `stagingHost` was being silently truncated through `getRootHost()`, and the `hasSubdomain` guard only fired on the `host` branch instead of every branch that produces a public URL.