### PR TITLE
fix(networking): keep multi-label localhost roots in getRootHost

### DIFF
--- a/src/shared/utils/networking.ts
+++ b/src/shared/utils/networking.ts
@@ -69,10 +69,15 @@ export const getRootHost = (host: string) => {
   const hostParts = host.split('.')
   const hostPartsLast = hostParts[hostParts.length - 1]
 
-  if (hostPartsLast && /^localhost(:[0-9]+)?$/.test(hostPartsLast))
-    return hostPartsLast
-
   if (hostParts.length === 1) return hostParts[0]
+
+  // only a single subdomain directly on bare localhost collapses to the root; e.g. app.localhost must keep its "app" label
+  if (
+    hostParts.length === 2 &&
+    hostPartsLast &&
+    /^localhost(:[0-9]+)?$/.test(hostPartsLast)
+  )
+    return hostPartsLast
 
   return `${hostParts[hostParts.length - 2]}.${hostPartsLast}`
 }


### PR DESCRIPTION
getRootHost collapsed any host ending in "localhost" down to the bare label, regardless of how many subdomain levels preceded it. This broke multi-label local roots like app.localhost (creal.app.localhost resolved to creal-strapi.localhost instead of creal-strapi.app.localhost). Now the collapse only applies when there's exactly one label in front of localhost.