### PR TITLE
fix(sentry): use a relative import for the layer-safe config

### DIFF
--- a/src/app/composables/sentry.ts
+++ b/src/app/composables/sentry.ts
@@ -1,4 +1,4 @@
-import { getSharedSentryConfig } from '~~/node/static'
+import { getSharedSentryConfig } from '../../node/static'
 
 export const useSharedSentryConfig = () => {
   const isTesting = useIsTesting()


### PR DESCRIPTION
The ~~ alias in `src/app/composables/sentry.ts` resolves against the consuming app's root when vio is extended as a layer, not vio's own root, so `nuxt typecheck` fails with `Cannot find module '~~/node/static'` for any project extending this layer. Switched to a relative import, matching how `nuxt.config.ts` already resolves the same module.