### PR TITLE
fix(testing): tolerate a missing request context in useIsTesting

### DIFF
--- a/src/server/utils/testing.ts
+++ b/src/server/utils/testing.ts
@@ -1,5 +1,15 @@
 import type { H3Event } from 'h3'
 
+// `useEvent()` throws whenever there is no Nitro request context, which is the case for everything that runs at startup, such as a Nitro plugin's hooks.
+// Testing detection still works there through the runtime config, so fall back to no event rather than letting that error escape.
+const tryUseEvent = () => {
+  try {
+    return useEvent()
+  } catch {
+    return undefined
+  }
+}
+
 export const useIsTesting = ({
   isCookieEnabled = true,
 }:
@@ -7,7 +17,7 @@ export const useIsTesting = ({
       isCookieEnabled?: boolean
     }
   | undefined = {}) => {
-  const event = useEvent()
+  const event = tryUseEvent()
   const runtimeConfig = useRuntimeConfig()
 
   return getIsTesting({ event, isCookieEnabled, runtimeConfig })


### PR DESCRIPTION
`useIsTesting` called `useEvent()` unconditionally, which throws whenever there is no Nitro request context.
That makes the composable unusable from anything running at startup, most notably a Nitro plugin's hooks, and by extension makes `useGetServiceHref` unusable there too.

A consumer hitting this gets no visible error: the throw surfaces as an unhandled rejection, the server keeps listening, and whatever the hook was building is silently dropped.
In creal's case that left the site serving a bare `default-src 'none'` policy with no `script-src` or `style-src` at all.

Cookie-based detection needs a request anyway, and the runtime config path does not, so falling back to no event keeps the useful half working instead of failing outright.